### PR TITLE
fix/auth security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.10.2] - 2026-07-15
+
+### Security
+
+- Removed bearer tokens, decoded claims, and parser details from application diagnostics
+- Required a nonblank JWT signing key of at least 32 UTF-8 bytes at startup
+- Bounded authentication inputs and normalized invalid refresh credentials to a generic response
+- Removed query-parameter bearer token support; clients must use the `Authorization` header
+- Added constant-time comparison for shared authentication secrets
+- Updated Spring Boot to 3.5.16 and patched Tomcat, Netty, Jackson, and PostgreSQL JDBC dependencies to clear all HIGH/CRITICAL CVEs
+
+### Testing
+
+- Added credential-leak and authentication-boundary regression tests
+
 ## [0.7.0] - 2025-10-22
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'org.jupytereverywhere'
-version = '0.10.1'
+version = '0.10.2'
 
 java {
 	toolchain {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
 	id 'jacoco'
-	id 'org.springframework.boot' version '3.5.12'
+	id 'org.springframework.boot' version '3.5.16'
 	id 'io.spring.dependency-management' version '1.1.6'
 	id("org.springdoc.openapi-gradle-plugin") version "1.9.0"
 	id 'org.openapi.generator' version '6.4.0'
@@ -19,13 +19,13 @@ java {
 }
 
 ext {
-	set('jackson-bom.version', '2.21.1')
+	set('jackson-bom.version', '2.21.5')
 	lombokVersion = '1.18.42'
 	jjwtVersion = '0.11.5'
 	awsSdkBomVersion = '2.35.0'
 	awsJdbcWrapperVersion = '2.6.5'
 	springdocVersion = '1.8.0'
-	postgresVersion = '42.7.8'
+	postgresVersion = '42.7.13'
 	classgraphVersion = '4.8.69'
 	webjarsVersion = '0.47'
 	persistenceApiVersion = '2.2'

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,7 +15,7 @@ This project follows **GitHub Flow**, a lightweight, trunk-based development str
 3. **Pull Requests** are opened when work is ready for review
 4. **CI/CD automatically validates** all PRs with tests and security scans
 5. **Merge to `main`** after PR approval and passing checks
-6. **Tag releases** when ready to deploy (e.g., `v0.3.4`)
+6. **Tag releases** when ready to deploy (e.g., `0.3.4`)
 7. **Deploy** by manually promoting tagged images through staging → production
 
 ### Branch Naming Conventions
@@ -31,7 +31,7 @@ Use descriptive branch names that clearly indicate the purpose:
 
 Releases are controlled via Git tags, not branches:
 
-- Tag with semantic versions (e.g., `v0.3.4`)
+- Tag with semantic versions (e.g., `0.3.4`)
 - All tags automatically trigger CI/CD pipeline that builds, scans, and pushes to ECR
 - Manually promote ECR images to staging/production environments
 
@@ -43,7 +43,7 @@ For critical production bugs:
 2. Fix the issue and open a PR
 3. CI/CD runs security scans and tests
 4. Merge to `main` after approval
-5. Tag immediately for deployment: `git tag v0.3.5`
+5. Tag immediately for deployment: `git tag 0.3.5`
 6. Deploy the hotfix image to production
 
 ## Prerequisites

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -94,8 +94,12 @@ If you want to develop and iterate on the Java code locally you need to do a lit
 4. Start the Java service using Gradle. You can do this directly, but there is a pre-configured script here:
 
    ```bash
+   export JWT_SECRET_KEY="$(openssl rand -hex 32)"
    ./start.sh
    ```
+
+   `JWT_SECRET_KEY` must be at least 32 UTF-8 bytes. The command above creates an ephemeral
+   local-development key; changing it invalidates previously issued local tokens.
 
 ### Troubleshooting Gradle
 
@@ -114,7 +118,8 @@ If something is wrong, or you are seeing exceptions try to solve this by cleanin
    gradle clean
    ```
 
-4. Then you can use `./gradlew bootRun` or `./start.sh` again to start the Java service.
+4. Then, with `JWT_SECRET_KEY` set as above, you can use `./gradlew bootRun` or `./start.sh`
+   again to start the Java service.
 
 ### Run the Tests
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -143,10 +143,8 @@ issue_token() {
     API_TOKEN=$(echo "${response}" | jq -r '.token' 2>/dev/null || echo "")
     if [[ -n "${API_TOKEN}" && "${API_TOKEN}" != "null" ]]; then
       log_success "Token issued successfully"
-      log_info "Token: ${YELLOW}${API_TOKEN}${NC}"
     else
       log_error "Failed to parse token from response"
-      log_error "Response: ${response}"
       exit 1
     fi
   else

--- a/src/main/java/org/jupytereverywhere/controller/AuthController.java
+++ b/src/main/java/org/jupytereverywhere/controller/AuthController.java
@@ -26,7 +26,6 @@ import lombok.extern.log4j.Log4j2;
 public class AuthController {
 
   private static final String MESSAGE_KEY = "Message";
-  private static final String TOKEN_KEY = "Token";
 
   private final AuthService authService;
 
@@ -53,10 +52,7 @@ public class AuthController {
   @PostMapping("/issue")
   public ResponseEntity<AuthenticationResponse> issueToken(
       @RequestBody(required = false) AuthenticationRequest authenticationRequest) {
-    logInfo(
-        "Received token issuance request",
-        "NotebookId",
-        authenticationRequest != null ? authenticationRequest.getNotebookId() : "None");
+    logInfo("Received token issuance request");
 
     try {
       AuthenticationResponse authenticationResponse =
@@ -64,10 +60,10 @@ public class AuthController {
       HttpHeaders headers =
           HttpHeaderUtils.createAuthorizationHeader(authenticationResponse.getToken());
 
-      logInfo("Initial token issued successfully", TOKEN_KEY, authenticationResponse.getToken());
+      logInfo("Initial token issued successfully");
       return ResponseEntity.ok().headers(headers).body(authenticationResponse);
     } catch (InvalidNotebookPasswordException e) {
-      logError("Invalid notebook ID or password", e);
+      logError("Initial token request rejected");
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
           .body(new AuthenticationResponse("Invalid notebook ID or password"));
     }
@@ -76,28 +72,28 @@ public class AuthController {
   @PostMapping("/refresh")
   public ResponseEntity<AuthenticationResponse> refreshToken(
       @RequestBody TokenRefreshRequest refreshRequest) {
-    logInfo("Received request to refresh JWT token", TOKEN_KEY, refreshRequest.getToken());
+    logInfo("Received request to refresh JWT token");
 
     try {
       AuthenticationResponse authenticationResponse =
           authService.refreshTokenResponse(refreshRequest.getToken());
-      logInfo("Token refreshed successfully", "NewToken", authenticationResponse.getToken());
+      logInfo("Token refreshed successfully");
       return ResponseEntity.ok(authenticationResponse);
     } catch (TokenRefreshException e) {
-      logError(refreshRequest.getToken(), e);
+      logError("Token refresh rejected");
       throw e;
     }
+  }
+
+  private void logInfo(String message) {
+    log.info(new StringMapMessage().with(MESSAGE_KEY, message));
   }
 
   private void logInfo(String message, String key, String value) {
     log.info(new StringMapMessage().with(MESSAGE_KEY, message).with(key, value));
   }
 
-  private void logError(String value, Exception e) {
-    log.error(
-        new StringMapMessage()
-            .with(MESSAGE_KEY, "Error refreshing token")
-            .with(AuthController.TOKEN_KEY, value),
-        e);
+  private void logError(String message) {
+    log.warn(new StringMapMessage().with(MESSAGE_KEY, message));
   }
 }

--- a/src/main/java/org/jupytereverywhere/controller/AuthController.java
+++ b/src/main/java/org/jupytereverywhere/controller/AuthController.java
@@ -51,7 +51,7 @@ public class AuthController {
 
   @PostMapping("/issue")
   public ResponseEntity<AuthenticationResponse> issueToken(
-      @RequestBody(required = false) AuthenticationRequest authenticationRequest) {
+      @Valid @RequestBody(required = false) AuthenticationRequest authenticationRequest) {
     logInfo("Received token issuance request");
 
     try {
@@ -71,7 +71,7 @@ public class AuthController {
 
   @PostMapping("/refresh")
   public ResponseEntity<AuthenticationResponse> refreshToken(
-      @RequestBody TokenRefreshRequest refreshRequest) {
+      @Valid @RequestBody TokenRefreshRequest refreshRequest) {
     logInfo("Received request to refresh JWT token");
 
     try {
@@ -81,7 +81,8 @@ public class AuthController {
       return ResponseEntity.ok(authenticationResponse);
     } catch (TokenRefreshException e) {
       logError("Token refresh rejected");
-      throw e;
+      return ResponseEntity.status(HttpStatus.FORBIDDEN)
+          .body(new AuthenticationResponse("Invalid or expired token"));
     }
   }
 

--- a/src/main/java/org/jupytereverywhere/exception/AuthExceptionHandler.java
+++ b/src/main/java/org/jupytereverywhere/exception/AuthExceptionHandler.java
@@ -1,0 +1,28 @@
+package org.jupytereverywhere.exception;
+
+import org.jupytereverywhere.controller.AuthController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = AuthController.class)
+public class AuthExceptionHandler {
+
+  public static final String MALFORMED_JSON_MESSAGE = "Malformed JSON request";
+  public static final String INVALID_REQUEST_MESSAGE = "Invalid request";
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<String> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(MALFORMED_JSON_MESSAGE);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<String> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(INVALID_REQUEST_MESSAGE);
+  }
+}

--- a/src/main/java/org/jupytereverywhere/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/jupytereverywhere/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package org.jupytereverywhere.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -10,13 +9,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class GlobalExceptionHandler {
 
   public static final String INVALID_NOTEBOOK_MESSAGE = "Invalid notebook: ";
-
-  @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<String> handleHttpMessageNotReadableException(
-      HttpMessageNotReadableException ex) {
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(INVALID_NOTEBOOK_MESSAGE + ex.getMessage());
-  }
 
   @ExceptionHandler(InvalidNotebookException.class)
   public ResponseEntity<String> handleInvalidNotebookException(InvalidNotebookException ex) {

--- a/src/main/java/org/jupytereverywhere/filter/JwtExtractor.java
+++ b/src/main/java/org/jupytereverywhere/filter/JwtExtractor.java
@@ -1,6 +1,7 @@
 package org.jupytereverywhere.filter;
 
 import org.apache.logging.log4j.message.StringMapMessage;
+import org.jupytereverywhere.utils.HttpHeaderUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -27,16 +28,11 @@ public class JwtExtractor {
   }
 
   public String extractJwtFromRequest(HttpServletRequest request) {
-    String header = request.getHeader("Authorization");
-    if (header != null && header.toLowerCase().startsWith("bearer ")) {
-      String jwt = header.substring(7).trim();
-      if (jwt.isEmpty()) {
-        return null;
-      }
+    String jwt = HttpHeaderUtils.extractBearerToken(request.getHeader("Authorization"));
+    if (jwt != null) {
       log.debug(new StringMapMessage().with(MESSAGE_KEY, "JWT Token detected"));
-      return jwt;
     }
-    return null;
+    return jwt;
   }
 
   public boolean validateExtraAuthHeader(HttpServletRequest request) {

--- a/src/main/java/org/jupytereverywhere/filter/JwtExtractor.java
+++ b/src/main/java/org/jupytereverywhere/filter/JwtExtractor.java
@@ -2,6 +2,7 @@ package org.jupytereverywhere.filter;
 
 import org.apache.logging.log4j.message.StringMapMessage;
 import org.jupytereverywhere.utils.HttpHeaderUtils;
+import org.jupytereverywhere.utils.SecretComparisonUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -52,7 +53,7 @@ public class JwtExtractor {
       log.debug(new StringMapMessage().with(MESSAGE_KEY, "Extra auth header present but empty"));
       return false;
     }
-    boolean isValid = extraAuthHeaderSecret.equals(headerValue);
+    boolean isValid = SecretComparisonUtils.constantTimeEquals(extraAuthHeaderSecret, headerValue);
     if (isValid) {
       log.debug(
           new StringMapMessage().with(MESSAGE_KEY, "Extra auth header validation successful"));

--- a/src/main/java/org/jupytereverywhere/filter/JwtRequestFilter.java
+++ b/src/main/java/org/jupytereverywhere/filter/JwtRequestFilter.java
@@ -112,10 +112,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
   private void handleExpiredToken(HttpServletResponse response, ExpiredJwtException e)
       throws IOException {
-    log.warn(
-        new StringMapMessage()
-            .with(MESSAGE_KEY, JWT_TOKEN_HAS_EXPIRED_MESSAGE)
-            .with(ERROR_MESSAGE_KEY, e.getMessage()));
+    log.warn(new StringMapMessage().with(MESSAGE_KEY, JWT_TOKEN_HAS_EXPIRED_MESSAGE));
     response.sendError(HttpServletResponse.SC_FORBIDDEN, JWT_TOKEN_HAS_EXPIRED_MESSAGE);
   }
 
@@ -124,8 +121,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     log.error(
         new StringMapMessage()
             .with(MESSAGE_KEY, "Error during JWT Token processing")
-            .with(ERROR_MESSAGE_KEY, e.getMessage()),
-        e);
+            .with(ERROR_MESSAGE_KEY, e.getClass().getSimpleName()));
     response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error processing JWT token");
   }
 

--- a/src/main/java/org/jupytereverywhere/model/auth/AdminTokenRequest.java
+++ b/src/main/java/org/jupytereverywhere/model/auth/AdminTokenRequest.java
@@ -1,6 +1,8 @@
 package org.jupytereverywhere.model.auth;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,9 +14,14 @@ import lombok.ToString;
 public class AdminTokenRequest {
 
   @NotBlank(message = "Secret cannot be blank")
+  @Size(max = 8192, message = "Secret is too long")
   @ToString.Exclude
   private String secret;
 
   @NotBlank(message = "Token name cannot be blank")
+  @Size(max = 100, message = "Token name is too long")
+  @Pattern(
+      regexp = "[A-Za-z0-9][A-Za-z0-9._-]*",
+      message = "Token name contains unsupported characters")
   private String tokenName;
 }

--- a/src/main/java/org/jupytereverywhere/model/auth/AuthenticationRequest.java
+++ b/src/main/java/org/jupytereverywhere/model/auth/AuthenticationRequest.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,9 +18,11 @@ import lombok.ToString;
 public class AuthenticationRequest {
 
   @NotBlank(message = "Notebook ID cannot be blank")
+  @Size(max = 36, message = "Notebook ID is too long")
   private String notebookId;
 
   @ToString.Exclude
   @NotBlank(message = "Password cannot be blank")
+  @Size(max = 1024, message = "Password is too long")
   private String password;
 }

--- a/src/main/java/org/jupytereverywhere/model/auth/AuthenticationResponse.java
+++ b/src/main/java/org/jupytereverywhere/model/auth/AuthenticationResponse.java
@@ -5,11 +5,12 @@ import org.springframework.stereotype.Component;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Component
 public class AuthenticationResponse {
-  private String token;
+  @ToString.Exclude private String token;
 }

--- a/src/main/java/org/jupytereverywhere/model/auth/TokenRefreshRequest.java
+++ b/src/main/java/org/jupytereverywhere/model/auth/TokenRefreshRequest.java
@@ -1,5 +1,7 @@
 package org.jupytereverywhere.model.auth;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,5 +11,8 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TokenRefreshRequest {
-  @ToString.Exclude private String token;
+  @ToString.Exclude
+  @NotBlank(message = "Token cannot be blank")
+  @Size(max = 8192, message = "Token is too long")
+  private String token;
 }

--- a/src/main/java/org/jupytereverywhere/model/auth/TokenRefreshRequest.java
+++ b/src/main/java/org/jupytereverywhere/model/auth/TokenRefreshRequest.java
@@ -3,10 +3,11 @@ package org.jupytereverywhere.model.auth;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class TokenRefreshRequest {
-  private String token;
+  @ToString.Exclude private String token;
 }

--- a/src/main/java/org/jupytereverywhere/model/request/JupyterNotebookRequest.java
+++ b/src/main/java/org/jupytereverywhere/model/request/JupyterNotebookRequest.java
@@ -7,12 +7,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class JupyterNotebookRequest {
-  private String password;
+  @ToString.Exclude private String password;
 
   @NotNull(message = "Notebook field is required and cannot be null")
   @Valid

--- a/src/main/java/org/jupytereverywhere/service/AuthService.java
+++ b/src/main/java/org/jupytereverywhere/service/AuthService.java
@@ -56,7 +56,7 @@ public class AuthService {
       }
     }
 
-    logStructuredMessage("Generating initial token for session", sessionId, token);
+    logStructuredMessage("Generating initial token for session", sessionId);
     tokenStore.storeToken(sessionId, token);
 
     return createAuthenticationResponse(token);
@@ -77,14 +77,14 @@ public class AuthService {
     String token =
         jwtTokenService.generateAdminToken(sessionId.toString(), adminRequest.getTokenName());
 
-    logStructuredMessage("Admin token issued", sessionId, token);
+    logStructuredMessage("Admin token issued", sessionId);
     tokenStore.storeToken(sessionId, token);
 
     return createAuthenticationResponse(token);
   }
 
   public AuthenticationResponse refreshTokenResponse(String token) {
-    logStructuredMessage("Refreshing JWT token", null, token);
+    logStructuredMessage("Refreshing JWT token", null);
 
     UUID sessionId = jwtTokenService.extractSessionIdFromToken(token);
     String notebookId = jwtTokenService.extractNotebookIdFromToken(token);
@@ -104,7 +104,7 @@ public class AuthService {
     }
     tokenStore.storeToken(sessionId, refreshedToken);
 
-    logStructuredMessage("Token refreshed successfully", sessionId, refreshedToken);
+    logStructuredMessage("Token refreshed successfully", sessionId);
     return createAuthenticationResponse(refreshedToken);
   }
 
@@ -121,13 +121,10 @@ public class AuthService {
     return false;
   }
 
-  private void logStructuredMessage(String message, UUID sessionId, String token) {
+  private void logStructuredMessage(String message, UUID sessionId) {
     StringMapMessage logMessage = new StringMapMessage().with("Message", message);
     if (sessionId != null) {
       logMessage.with("SessionId", sessionId.toString());
-    }
-    if (token != null) {
-      logMessage.with("Token", token);
     }
     log.info(logMessage);
   }

--- a/src/main/java/org/jupytereverywhere/service/AuthService.java
+++ b/src/main/java/org/jupytereverywhere/service/AuthService.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.apache.logging.log4j.message.StringMapMessage;
 import org.jupytereverywhere.exception.InvalidNotebookPasswordException;
+import org.jupytereverywhere.exception.NotebookNotFoundException;
 import org.jupytereverywhere.exception.TokenRefreshException;
 import org.jupytereverywhere.model.JupyterNotebookEntity;
 import org.jupytereverywhere.model.TokenStore;
@@ -19,6 +20,8 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @Service
 public class AuthService {
+
+  private static final String INVALID_TOKEN_MESSAGE = "Invalid or expired token";
 
   private final JwtTokenService jwtTokenService;
   private final TokenStore tokenStore;
@@ -48,10 +51,13 @@ public class AuthService {
         || authRequest.getPassword() == null) {
       token = jwtTokenService.generateToken(sessionId.toString());
     } else {
-      if (verifyNotebookPassword(
-          UUID.fromString(authRequest.getNotebookId()), authRequest.getPassword())) {
-        token = jwtTokenService.generateToken(sessionId.toString(), authRequest.getNotebookId());
-      } else {
+      try {
+        UUID notebookId = UUID.fromString(authRequest.getNotebookId());
+        if (!verifyNotebookPassword(notebookId, authRequest.getPassword())) {
+          throw new InvalidNotebookPasswordException("Invalid notebook ID or password");
+        }
+        token = jwtTokenService.generateToken(sessionId.toString(), notebookId.toString());
+      } catch (IllegalArgumentException | NotebookNotFoundException e) {
         throw new InvalidNotebookPasswordException("Invalid notebook ID or password");
       }
     }
@@ -86,12 +92,26 @@ public class AuthService {
   public AuthenticationResponse refreshTokenResponse(String token) {
     logStructuredMessage("Refreshing JWT token", null);
 
+    if (token == null || token.isBlank()) {
+      throw new TokenRefreshException(INVALID_TOKEN_MESSAGE);
+    }
+
+    try {
+      return refreshValidatedToken(token);
+    } catch (TokenRefreshException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new TokenRefreshException(INVALID_TOKEN_MESSAGE);
+    }
+  }
+
+  private AuthenticationResponse refreshValidatedToken(String token) {
     UUID sessionId = jwtTokenService.extractSessionIdFromToken(token);
     String notebookId = jwtTokenService.extractNotebookIdFromToken(token);
     String role = jwtTokenService.extractRoleFromToken(token);
     String tokenName = jwtTokenService.extractTokenNameFromToken(token);
     if (sessionId == null || !isTokenValid(token, sessionId)) {
-      throw new TokenRefreshException("Invalid or expired session ID");
+      throw new TokenRefreshException(INVALID_TOKEN_MESSAGE);
     }
 
     tokenStore.removeToken(sessionId);

--- a/src/main/java/org/jupytereverywhere/service/AuthService.java
+++ b/src/main/java/org/jupytereverywhere/service/AuthService.java
@@ -11,6 +11,7 @@ import org.jupytereverywhere.model.TokenStore;
 import org.jupytereverywhere.model.auth.AdminTokenRequest;
 import org.jupytereverywhere.model.auth.AuthenticationRequest;
 import org.jupytereverywhere.model.auth.AuthenticationResponse;
+import org.jupytereverywhere.utils.SecretComparisonUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -71,7 +72,7 @@ public class AuthService {
   public AuthenticationResponse generateAdminTokenResponse(AdminTokenRequest adminRequest) {
     if (adminSecret == null
         || adminSecret.isEmpty()
-        || !adminSecret.equals(adminRequest.getSecret())) {
+        || !SecretComparisonUtils.constantTimeEquals(adminSecret, adminRequest.getSecret())) {
       log.warn(
           new StringMapMessage()
               .with("Message", "Invalid admin secret presented")

--- a/src/main/java/org/jupytereverywhere/service/JwtTokenService.java
+++ b/src/main/java/org/jupytereverywhere/service/JwtTokenService.java
@@ -30,6 +30,7 @@ public class JwtTokenService {
   public static final String ROLE = "role";
   public static final String TOKEN_NAME = "token_name";
   public static final String ADMIN_ROLE = "ADMIN";
+  private static final int MIN_SIGNING_KEY_BYTES = 32;
   private final SecretKey secretKey;
   private final JwtParser jwtParser;
   private final int expirationMinutes;
@@ -38,6 +39,9 @@ public class JwtTokenService {
       @Value("${security.jwt.token.secret-key}") String secretKey,
       @Value("${security.jwt.token.expiration-minutes}") int expirationMinutes,
       PasswordEncoder passwordEncoder) {
+    if (expirationMinutes <= 0) {
+      throw new IllegalArgumentException("JWT expiration must be greater than zero");
+    }
     this.secretKey = createSecretKey(secretKey);
     this.jwtParser =
         Jwts.parserBuilder().setSigningKey(this.secretKey).setAllowedClockSkewSeconds(60).build();
@@ -45,7 +49,13 @@ public class JwtTokenService {
   }
 
   private SecretKey createSecretKey(String secretKeyString) {
+    if (secretKeyString == null || secretKeyString.isBlank()) {
+      throw new IllegalArgumentException("JWT signing key must be configured");
+    }
     byte[] keyBytes = secretKeyString.getBytes(StandardCharsets.UTF_8);
+    if (keyBytes.length < MIN_SIGNING_KEY_BYTES) {
+      throw new IllegalArgumentException("JWT signing key must contain at least 32 UTF-8 bytes");
+    }
     return new SecretKeySpec(keyBytes, "HmacSHA256");
   }
 

--- a/src/main/java/org/jupytereverywhere/service/JwtTokenService.java
+++ b/src/main/java/org/jupytereverywhere/service/JwtTokenService.java
@@ -86,8 +86,8 @@ public class JwtTokenService {
     try {
       Claims claims = extractAllClaims(token);
       return claims.get(ROLE, String.class);
-    } catch (JwtException e) {
-      log.error("Invalid JWT token: {}", e.getMessage());
+    } catch (JwtException | IllegalArgumentException e) {
+      log.warn("JWT role extraction failed");
       return null;
     }
   }
@@ -99,8 +99,8 @@ public class JwtTokenService {
     try {
       Claims claims = extractAllClaims(token);
       return claims.get(TOKEN_NAME, String.class);
-    } catch (JwtException e) {
-      log.error("Invalid JWT token: {}", e.getMessage());
+    } catch (JwtException | IllegalArgumentException e) {
+      log.warn("JWT token-name extraction failed");
       return null;
     }
   }
@@ -121,7 +121,7 @@ public class JwtTokenService {
 
       return UUID.fromString(sessionId);
     } catch (ExpiredJwtException e) {
-      log.warn("Token has expired, extracting session ID from claims: {}", e.getClaims());
+      log.warn("Expired JWT session claim requested");
       String sessionId = e.getClaims().get(SESSION_ID, String.class);
       if (sessionId == null || sessionId.isEmpty()) {
         throw new IllegalArgumentException(
@@ -129,8 +129,8 @@ public class JwtTokenService {
       }
       return UUID.fromString(sessionId);
     } catch (JwtException e) {
-      log.error("Invalid JWT token: {}", e.getMessage());
-      throw new IllegalArgumentException("Invalid JWT token", e);
+      log.warn("JWT session extraction failed");
+      throw new IllegalArgumentException("Invalid JWT token");
     }
   }
 
@@ -143,11 +143,11 @@ public class JwtTokenService {
       Claims claims = extractAllClaims(token);
       return claims.get(NOTEBOOK_ID, String.class);
     } catch (ExpiredJwtException e) {
-      log.warn("Token has expired, extracting notebook ID from claims: {}", e.getClaims());
+      log.warn("Expired JWT notebook claim requested");
       return e.getClaims().get(NOTEBOOK_ID, String.class);
     } catch (JwtException e) {
-      log.error("Invalid JWT token: {}", e.getMessage());
-      throw new IllegalArgumentException("Invalid JWT token", e);
+      log.warn("JWT notebook extraction failed");
+      throw new IllegalArgumentException("Invalid JWT token");
     }
   }
 
@@ -156,7 +156,7 @@ public class JwtTokenService {
       Claims claims = extractAllClaims(token);
       return !claims.getExpiration().before(new Date());
     } catch (JwtException | IllegalArgumentException e) {
-      log.error("Token validation failed: {}", e.getMessage());
+      log.warn("JWT validation failed");
       return false;
     }
   }
@@ -168,7 +168,7 @@ public class JwtTokenService {
     try {
       return extractExpiration(token).before(new Date());
     } catch (JwtException e) {
-      log.error("Failed to check token expiration: {}", e.getMessage());
+      log.warn("JWT expiration check failed");
       return true;
     }
   }
@@ -185,11 +185,11 @@ public class JwtTokenService {
     try {
       return jwtParser.parseClaimsJws(token).getBody();
     } catch (ExpiredJwtException e) {
-      log.warn("Token has expired, returning claims: {}", e.getClaims());
+      log.warn("Expired JWT claims requested");
       return e.getClaims();
     } catch (JwtException e) {
-      log.error("Invalid JWT token: {}", e.getMessage());
-      throw new IllegalArgumentException("Invalid JWT token", e);
+      log.warn("JWT parsing failed");
+      throw new IllegalArgumentException("Invalid JWT token");
     }
   }
 }

--- a/src/main/java/org/jupytereverywhere/utils/HttpHeaderUtils.java
+++ b/src/main/java/org/jupytereverywhere/utils/HttpHeaderUtils.java
@@ -86,18 +86,22 @@ public class HttpHeaderUtils {
   }
 
   public static String getTokenFromRequest(HttpServletRequest request) {
-
-    String authorizationHeader = request.getHeader("Authorization");
-    if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-      return authorizationHeader.substring(7);
+    String token = extractBearerToken(request.getHeader("Authorization"));
+    if (token != null) {
+      return token;
     }
 
-    String tokenFromQuery = request.getParameter("token");
-    if (tokenFromQuery != null && !tokenFromQuery.isEmpty()) {
-      return tokenFromQuery;
+    throw new IllegalArgumentException("No bearer token found in the Authorization header");
+  }
+
+  public static String extractBearerToken(String authorizationHeader) {
+    if (authorizationHeader == null
+        || !authorizationHeader.regionMatches(true, 0, "Bearer ", 0, 7)) {
+      return null;
     }
 
-    throw new IllegalArgumentException("No token found in the request");
+    String token = authorizationHeader.substring(7).trim();
+    return token.isEmpty() ? null : token;
   }
 
   private static void logInfo(String message, String key, String value) {

--- a/src/main/java/org/jupytereverywhere/utils/SecretComparisonUtils.java
+++ b/src/main/java/org/jupytereverywhere/utils/SecretComparisonUtils.java
@@ -1,0 +1,18 @@
+package org.jupytereverywhere.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+public final class SecretComparisonUtils {
+
+  private SecretComparisonUtils() {}
+
+  public static boolean constantTimeEquals(String expected, String actual) {
+    if (expected == null || actual == null) {
+      return false;
+    }
+
+    return MessageDigest.isEqual(
+        expected.getBytes(StandardCharsets.UTF_8), actual.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/resources/api.yaml
+++ b/src/main/resources/api.yaml
@@ -10,11 +10,28 @@ servers:
 
 paths:
   /auth/issue:
-    get:
+    post:
       summary: Issue initial JWT token
-      description: Issue a JWT token for the user when they first visit the website. This token will be used for subsequent API requests and will include session data.
+      description: Issue an anonymous JWT when the body is omitted, or a notebook-scoped JWT when valid notebook credentials are supplied.
       tags:
         - Authentication
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notebookId:
+                  type: string
+                  format: uuid
+                  maxLength: 36
+                password:
+                  type: string
+                  maxLength: 1024
+              required:
+                - notebookId
+                - password
       responses:
         "200":
           description: Initial JWT token issued successfully
@@ -35,6 +52,23 @@ paths:
                     example: "initialJWTTokenHere"
         "403":
           $ref: "#/components/responses/OriginMismatch"
+        "400":
+          description: Malformed or invalid authentication request
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Invalid request"
+        "401":
+          description: Invalid notebook ID or password
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    example: "Invalid notebook ID or password"
         "500":
           $ref: "#/components/responses/TokenGenerationError"
   /auth/refresh:
@@ -52,8 +86,11 @@ paths:
               properties:
                 token:
                   type: string
+                  maxLength: 8192
                   description: "The current valid JWT that is about to expire."
                   example: "currentJWTTokenHere"
+              required:
+                - token
       responses:
         "200":
           description: JWT refreshed successfully
@@ -66,8 +103,23 @@ paths:
                     type: string
                     description: "The new JWT token with an extended expiration time."
                     example: "newJWTTokenHere"
+        "400":
+          description: Malformed or invalid refresh request
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Invalid request"
         "403":
-          $ref: "#/components/responses/InvalidJWT"
+          description: Invalid or expired refresh token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    example: "Invalid or expired token"
         "500":
           $ref: "#/components/responses/TokenGenerationError"
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ cors.allow-credentials=${CORS_ALLOW_CREDENTIALS:true}
 cors.max-age=${CORS_MAX_AGE:7200}
 
 # JWT Configurations
-security.jwt.token.secret-key=${JWT_SECRET_KEY:fake-jwt-secret-value}
+security.jwt.token.secret-key=${JWT_SECRET_KEY}
 security.jwt.token.expiration-minutes=${JWT_EXPIRATION_MINUTES:120}
 
 # Admin Authentication

--- a/src/test/java/org/jupytereverywhere/controller/AuthControllerTest.java
+++ b/src/test/java/org/jupytereverywhere/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package org.jupytereverywhere.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,11 +21,14 @@ import org.jupytereverywhere.service.AuthService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 class AuthControllerTest {
 
   @InjectMocks private AuthController authController;
@@ -35,9 +39,10 @@ class AuthControllerTest {
   public void setUp() {}
 
   @Test
-  void testIssueToken_Success_WithAuthenticationRequest() {
+  void testIssueToken_Success_WithAuthenticationRequest(CapturedOutput output) {
+    String submittedNotebookId = "submitted-notebook-id-sentinel";
     AuthenticationRequest authenticationRequest = new AuthenticationRequest();
-    authenticationRequest.setNotebookId("notebook-id");
+    authenticationRequest.setNotebookId(submittedNotebookId);
     authenticationRequest.setPassword("password");
 
     AuthenticationResponse expectedResponse = new AuthenticationResponse("generated-token");
@@ -58,6 +63,8 @@ class AuthControllerTest {
     AuthenticationResponse responseBody = responseEntity.getBody();
     assertNotNull(responseBody);
     assertEquals("generated-token", responseBody.getToken());
+    assertFalse(output.getAll().contains("generated-token"));
+    assertFalse(output.getAll().contains(submittedNotebookId));
 
     verify(authService, times(1)).generateInitialTokenResponse(authenticationRequest);
   }
@@ -131,9 +138,11 @@ class AuthControllerTest {
   }
 
   @Test
-  void testRefreshToken_Success() {
-    TokenRefreshRequest refreshRequest = new TokenRefreshRequest("valid-refresh-token");
-    AuthenticationResponse expectedResponse = new AuthenticationResponse("refreshed-token");
+  void testRefreshToken_Success(CapturedOutput output) {
+    String submittedToken = "submitted-refresh-token-sentinel";
+    String refreshedToken = "refreshed-token-sentinel";
+    TokenRefreshRequest refreshRequest = new TokenRefreshRequest(submittedToken);
+    AuthenticationResponse expectedResponse = new AuthenticationResponse(refreshedToken);
 
     when(authService.refreshTokenResponse(refreshRequest.getToken())).thenReturn(expectedResponse);
 
@@ -145,14 +154,17 @@ class AuthControllerTest {
 
     AuthenticationResponse responseBody = responseEntity.getBody();
     assertNotNull(responseBody);
-    assertEquals("refreshed-token", responseBody.getToken());
+    assertEquals(refreshedToken, responseBody.getToken());
+    assertFalse(output.getAll().contains(submittedToken));
+    assertFalse(output.getAll().contains(refreshedToken));
 
     verify(authService, times(1)).refreshTokenResponse(refreshRequest.getToken());
   }
 
   @Test
-  void testRefreshToken_TokenRefreshException() {
-    TokenRefreshRequest refreshRequest = new TokenRefreshRequest("invalid-refresh-token");
+  void testRefreshToken_TokenRefreshException(CapturedOutput output) {
+    String submittedToken = "rejected-refresh-token-sentinel";
+    TokenRefreshRequest refreshRequest = new TokenRefreshRequest(submittedToken);
 
     when(authService.refreshTokenResponse(refreshRequest.getToken()))
         .thenThrow(new TokenRefreshException("Token refresh failed"));
@@ -165,6 +177,7 @@ class AuthControllerTest {
             });
 
     assertEquals("Token refresh failed", exception.getMessage());
+    assertFalse(output.getAll().contains(submittedToken));
 
     verify(authService, times(1)).refreshTokenResponse(refreshRequest.getToken());
   }

--- a/src/test/java/org/jupytereverywhere/controller/AuthControllerTest.java
+++ b/src/test/java/org/jupytereverywhere/controller/AuthControllerTest.java
@@ -169,14 +169,11 @@ class AuthControllerTest {
     when(authService.refreshTokenResponse(refreshRequest.getToken()))
         .thenThrow(new TokenRefreshException("Token refresh failed"));
 
-    TokenRefreshException exception =
-        assertThrows(
-            TokenRefreshException.class,
-            () -> {
-              authController.refreshToken(refreshRequest);
-            });
+    ResponseEntity<AuthenticationResponse> response = authController.refreshToken(refreshRequest);
 
-    assertEquals("Token refresh failed", exception.getMessage());
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals("Invalid or expired token", response.getBody().getToken());
     assertFalse(output.getAll().contains(submittedToken));
 
     verify(authService, times(1)).refreshTokenResponse(refreshRequest.getToken());

--- a/src/test/java/org/jupytereverywhere/controller/AuthControllerWebTest.java
+++ b/src/test/java/org/jupytereverywhere/controller/AuthControllerWebTest.java
@@ -1,0 +1,117 @@
+package org.jupytereverywhere.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.jupytereverywhere.exception.AuthExceptionHandler;
+import org.jupytereverywhere.exception.TokenRefreshException;
+import org.jupytereverywhere.model.auth.AuthenticationRequest;
+import org.jupytereverywhere.model.auth.AuthenticationResponse;
+import org.jupytereverywhere.service.AuthService;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerWebTest {
+
+  @Mock private AuthService authService;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(new AuthController(authService))
+            .setControllerAdvice(new AuthExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void noIssueBodyRemainsAnonymousIssuance() throws Exception {
+    when(authService.generateInitialTokenResponse(null))
+        .thenReturn(new AuthenticationResponse("anonymous-token"));
+
+    mockMvc
+        .perform(post("/auth/issue").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.token").value("anonymous-token"));
+
+    verify(authService).generateInitialTokenResponse(null);
+  }
+
+  @Test
+  void emptyOrPartialIssueBodiesAreRejectedAtHttpBoundary() throws Exception {
+    mockMvc
+        .perform(post("/auth/issue").contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string(AuthExceptionHandler.INVALID_REQUEST_MESSAGE));
+    mockMvc
+        .perform(
+            post("/auth/issue")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"notebookId\":\"00000000-0000-0000-0000-000000000000\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string(AuthExceptionHandler.INVALID_REQUEST_MESSAGE));
+
+    verifyNoInteractions(authService);
+  }
+
+  @Test
+  void oversizedIssueCredentialsAreRejectedWithoutReflection() throws Exception {
+    String sentinel = "submitted-password-sentinel-" + "x".repeat(1025);
+
+    mockMvc
+        .perform(
+            post("/auth/issue")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"notebookId\":\"00000000-0000-0000-0000-000000000000\",\"password\":\""
+                        + sentinel
+                        + "\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string(AuthExceptionHandler.INVALID_REQUEST_MESSAGE));
+
+    verify(authService, never()).generateInitialTokenResponse(any(AuthenticationRequest.class));
+  }
+
+  @Test
+  void refreshValidationAndMalformedJsonReturnFixedMessages() throws Exception {
+    mockMvc
+        .perform(post("/auth/refresh").contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string(AuthExceptionHandler.INVALID_REQUEST_MESSAGE));
+    mockMvc
+        .perform(post("/auth/refresh").contentType(MediaType.APPLICATION_JSON).content("{"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string(AuthExceptionHandler.MALFORMED_JSON_MESSAGE));
+
+    verifyNoInteractions(authService);
+  }
+
+  @Test
+  void invalidRefreshUsesGenericForbiddenResponse() throws Exception {
+    when(authService.refreshTokenResponse("rejected-token"))
+        .thenThrow(new TokenRefreshException("parser detail sentinel"));
+
+    mockMvc
+        .perform(
+            post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"token\":\"rejected-token\"}"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.token").value("Invalid or expired token"));
+  }
+}

--- a/src/test/java/org/jupytereverywhere/exception/AuthExceptionHandlerTest.java
+++ b/src/test/java/org/jupytereverywhere/exception/AuthExceptionHandlerTest.java
@@ -1,0 +1,40 @@
+package org.jupytereverywhere.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+class AuthExceptionHandlerTest {
+
+  @Test
+  void malformedJsonResponseDoesNotExposeParserDetails() {
+    String sensitiveDetail = "submitted-credential-sentinel";
+    HttpMessageNotReadableException exception =
+        new HttpMessageNotReadableException(sensitiveDetail, mock(HttpInputMessage.class));
+
+    ResponseEntity<String> response =
+        new AuthExceptionHandler().handleHttpMessageNotReadableException(exception);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(AuthExceptionHandler.MALFORMED_JSON_MESSAGE, response.getBody());
+    assertFalse(response.getBody().contains(sensitiveDetail));
+  }
+
+  @Test
+  void validationResponseDoesNotExposeRejectedValue() {
+    MethodArgumentNotValidException exception = mock(MethodArgumentNotValidException.class);
+
+    ResponseEntity<String> response =
+        new AuthExceptionHandler().handleMethodArgumentNotValidException(exception);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(AuthExceptionHandler.INVALID_REQUEST_MESSAGE, response.getBody());
+  }
+}

--- a/src/test/java/org/jupytereverywhere/filter/JwtRequestFilterTest.java
+++ b/src/test/java/org/jupytereverywhere/filter/JwtRequestFilterTest.java
@@ -1,6 +1,7 @@
 package org.jupytereverywhere.filter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -18,6 +19,8 @@ import org.jupytereverywhere.service.JwtTokenService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,6 +31,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 class JwtRequestFilterTest {
 
   @InjectMocks private JwtRequestFilter jwtRequestFilter;
@@ -134,7 +138,8 @@ class JwtRequestFilterTest {
   }
 
   @Test
-  void testDoFilterInternal_ExceptionDuringProcessing() throws ServletException, IOException {
+  void testDoFilterInternal_ExceptionDuringProcessing(CapturedOutput output)
+      throws ServletException, IOException {
     String token = "someTokenString";
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("Authorization", "Bearer " + token);
@@ -142,7 +147,8 @@ class JwtRequestFilterTest {
     FilterChain filterChain = mock(FilterChain.class);
 
     when(jwtExtractor.extractJwtFromRequest(request)).thenReturn(token);
-    when(jwtValidator.isValid(token)).thenThrow(new RuntimeException("Unexpected error"));
+    String sensitiveMessage = "token-processing-error-sentinel";
+    when(jwtValidator.isValid(token)).thenThrow(new RuntimeException(sensitiveMessage));
 
     jwtRequestFilter.doFilterInternal(request, response, filterChain);
 
@@ -150,6 +156,8 @@ class JwtRequestFilterTest {
     verify(jwtTokenService, never()).extractSessionIdFromToken(anyString());
     verify(filterChain, never()).doFilter(request, response);
     assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response.getStatus());
+    assertFalse(output.getAll().contains(token));
+    assertFalse(output.getAll().contains(sensitiveMessage));
   }
 
   @Test

--- a/src/test/java/org/jupytereverywhere/model/auth/AdminTokenRequestTest.java
+++ b/src/test/java/org/jupytereverywhere/model/auth/AdminTokenRequestTest.java
@@ -1,0 +1,47 @@
+package org.jupytereverywhere.model.auth;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+class AdminTokenRequestTest {
+
+  private Validator validator;
+
+  @BeforeEach
+  void setUp() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  void validationAcceptsSupportedTokenName() {
+    assertTrue(validator.validate(new AdminTokenRequest("value", "ops-team_1.test")).isEmpty());
+  }
+
+  @Test
+  void validationRejectsUnsupportedOrOversizedTokenName() {
+    Set<ConstraintViolation<AdminTokenRequest>> unsupported =
+        validator.validate(new AdminTokenRequest("value", "ops team"));
+    Set<ConstraintViolation<AdminTokenRequest>> oversized =
+        validator.validate(new AdminTokenRequest("value", "x".repeat(101)));
+
+    assertFalse(unsupported.isEmpty());
+    assertFalse(oversized.isEmpty());
+  }
+
+  @Test
+  void toStringExcludesSecret() {
+    String sensitiveValue = "admin-value-sentinel";
+    AdminTokenRequest request = new AdminTokenRequest(sensitiveValue, "ops-team");
+
+    assertFalse(request.toString().contains(sensitiveValue));
+  }
+}

--- a/src/test/java/org/jupytereverywhere/model/auth/AuthenticationRequestTest.java
+++ b/src/test/java/org/jupytereverywhere/model/auth/AuthenticationRequestTest.java
@@ -1,20 +1,28 @@
 package org.jupytereverywhere.model.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
 class AuthenticationRequestTest {
 
   private AuthenticationRequest authenticationRequest;
+  private Validator validator;
 
   @BeforeEach
   public void setUp() {
     authenticationRequest = new AuthenticationRequest();
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
   }
 
   @Test
@@ -108,14 +116,24 @@ class AuthenticationRequestTest {
   }
 
   @Test
-  void testNotBlankValidation_NotebookId() {
-    AuthenticationRequest request = new AuthenticationRequest("", "testPassword");
-    assertTrue(request.getNotebookId().isBlank(), "NotebookId should be blank");
+  void validationRejectsBlankAndOversizedNotebookId() {
+    Set<ConstraintViolation<AuthenticationRequest>> blankViolations =
+        validator.validate(new AuthenticationRequest("", "testPassword"));
+    Set<ConstraintViolation<AuthenticationRequest>> oversizedViolations =
+        validator.validate(new AuthenticationRequest("x".repeat(37), "testPassword"));
+
+    assertFalse(blankViolations.isEmpty());
+    assertFalse(oversizedViolations.isEmpty());
   }
 
   @Test
-  void testNotBlankValidation_Password() {
-    AuthenticationRequest request = new AuthenticationRequest("notebook-123", "");
-    assertTrue(request.getPassword().isBlank(), "Password should be blank");
+  void validationRejectsBlankAndOversizedPassword() {
+    Set<ConstraintViolation<AuthenticationRequest>> blankViolations =
+        validator.validate(new AuthenticationRequest("notebook-123", ""));
+    Set<ConstraintViolation<AuthenticationRequest>> oversizedViolations =
+        validator.validate(new AuthenticationRequest("notebook-123", "x".repeat(1025)));
+
+    assertFalse(blankViolations.isEmpty());
+    assertFalse(oversizedViolations.isEmpty());
   }
 }

--- a/src/test/java/org/jupytereverywhere/model/auth/AuthenticationResponseTest.java
+++ b/src/test/java/org/jupytereverywhere/model/auth/AuthenticationResponseTest.java
@@ -38,9 +38,9 @@ class AuthenticationResponseTest {
 
   @Test
   void testToString() {
-    authenticationResponse.setToken("sampleToken");
-    String expectedString = "AuthenticationResponse(token=sampleToken)";
-    assertEquals(expectedString, authenticationResponse.toString());
+    String token = "sensitive-token-sentinel";
+    authenticationResponse.setToken(token);
+    assertFalse(authenticationResponse.toString().contains(token));
   }
 
   @Test

--- a/src/test/java/org/jupytereverywhere/model/auth/TokenRefreshRequestTest.java
+++ b/src/test/java/org/jupytereverywhere/model/auth/TokenRefreshRequestTest.java
@@ -44,12 +44,9 @@ class TokenRefreshRequestTest {
 
   @Test
   void testToString() {
-    tokenRefreshRequest.setToken("sampleToken");
-    String expectedString = "TokenRefreshRequest(token=sampleToken)";
-    assertEquals(
-        expectedString,
-        tokenRefreshRequest.toString(),
-        "toString output should match the expected format");
+    String token = "sensitive-token-sentinel";
+    tokenRefreshRequest.setToken(token);
+    assertFalse(tokenRefreshRequest.toString().contains(token));
   }
 
   @Test

--- a/src/test/java/org/jupytereverywhere/model/auth/TokenRefreshRequestTest.java
+++ b/src/test/java/org/jupytereverywhere/model/auth/TokenRefreshRequestTest.java
@@ -6,16 +6,24 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 class TokenRefreshRequestTest {
 
   private TokenRefreshRequest tokenRefreshRequest;
+  private Validator validator;
 
   @BeforeEach
   public void setUp() {
     tokenRefreshRequest = new TokenRefreshRequest();
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
   }
 
   @Test
@@ -115,5 +123,16 @@ class TokenRefreshRequestTest {
     assertFalse(
         request.canEqual("Some String"),
         "canEqual should return false for objects of different types");
+  }
+
+  @Test
+  void testValidationRejectsBlankAndOversizedTokens() {
+    Set<ConstraintViolation<TokenRefreshRequest>> blankViolations =
+        validator.validate(new TokenRefreshRequest(" "));
+    Set<ConstraintViolation<TokenRefreshRequest>> oversizedViolations =
+        validator.validate(new TokenRefreshRequest("x".repeat(8193)));
+
+    assertFalse(blankViolations.isEmpty());
+    assertFalse(oversizedViolations.isEmpty());
   }
 }

--- a/src/test/java/org/jupytereverywhere/service/AuthServiceTest.java
+++ b/src/test/java/org/jupytereverywhere/service/AuthServiceTest.java
@@ -10,13 +10,17 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.jupytereverywhere.exception.InvalidNotebookPasswordException;
+import org.jupytereverywhere.exception.NotebookNotFoundException;
 import org.jupytereverywhere.exception.TokenRefreshException;
+import org.jupytereverywhere.model.JupyterNotebookEntity;
 import org.jupytereverywhere.model.TokenStore;
 import org.jupytereverywhere.model.auth.AdminTokenRequest;
 import org.jupytereverywhere.model.auth.AuthenticationRequest;
@@ -28,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,6 +43,10 @@ class AuthServiceTest {
   @Mock private JwtTokenService jwtTokenService;
 
   @Mock private TokenStore tokenStore;
+
+  @Mock private JupyterNotebookService notebookService;
+
+  @Mock private PasswordEncoder passwordEncoder;
 
   @InjectMocks private AuthService authService;
 
@@ -54,6 +63,56 @@ class AuthServiceTest {
     assertFalse(output.getAll().contains(expectedToken));
     verify(jwtTokenService).generateToken(anyString());
     verify(tokenStore).storeToken(any(UUID.class), eq(expectedToken));
+  }
+
+  @Test
+  void testGenerateInitialTokenResponse_MalformedNotebookIdIsNormalized() {
+    AuthenticationRequest request = new AuthenticationRequest("not-a-uuid", "password");
+
+    InvalidNotebookPasswordException exception =
+        assertThrows(
+            InvalidNotebookPasswordException.class,
+            () -> authService.generateInitialTokenResponse(request));
+
+    assertEquals("Invalid notebook ID or password", exception.getMessage());
+    verifyNoInteractions(notebookService);
+    verify(tokenStore, never()).storeToken(any(UUID.class), anyString());
+  }
+
+  @Test
+  void testGenerateInitialTokenResponse_UnknownNotebookIsNormalized() {
+    UUID notebookId = UUID.randomUUID();
+    when(notebookService.getNotebookById(notebookId))
+        .thenThrow(new NotebookNotFoundException("database detail sentinel"));
+
+    InvalidNotebookPasswordException exception =
+        assertThrows(
+            InvalidNotebookPasswordException.class,
+            () ->
+                authService.generateInitialTokenResponse(
+                    new AuthenticationRequest(notebookId.toString(), "password")));
+
+    assertEquals("Invalid notebook ID or password", exception.getMessage());
+    verify(tokenStore, never()).storeToken(any(UUID.class), anyString());
+  }
+
+  @Test
+  void testGenerateInitialTokenResponse_WrongPasswordUsesSameResponse() {
+    UUID notebookId = UUID.randomUUID();
+    JupyterNotebookEntity notebook = new JupyterNotebookEntity();
+    notebook.setPassword("encoded-password");
+    when(notebookService.getNotebookById(notebookId)).thenReturn(notebook);
+    when(passwordEncoder.matches("wrong-password", "encoded-password")).thenReturn(false);
+
+    InvalidNotebookPasswordException exception =
+        assertThrows(
+            InvalidNotebookPasswordException.class,
+            () ->
+                authService.generateInitialTokenResponse(
+                    new AuthenticationRequest(notebookId.toString(), "wrong-password")));
+
+    assertEquals("Invalid notebook ID or password", exception.getMessage());
+    verify(tokenStore, never()).storeToken(any(UUID.class), anyString());
   }
 
   @Test
@@ -96,6 +155,28 @@ class AuthServiceTest {
     verify(jwtTokenService, never()).generateToken(anyString());
     verify(tokenStore, never()).removeToken(any(UUID.class));
     verify(tokenStore, never()).storeToken(any(UUID.class), anyString());
+  }
+
+  @Test
+  void testRefreshTokenResponse_Failure_MalformedTokenIsNormalized() {
+    String malformedToken = "malformed-token";
+    when(jwtTokenService.extractSessionIdFromToken(malformedToken))
+        .thenThrow(new IllegalArgumentException("parser detail sentinel"));
+
+    TokenRefreshException exception =
+        assertThrows(
+            TokenRefreshException.class, () -> authService.refreshTokenResponse(malformedToken));
+
+    assertEquals("Invalid or expired token", exception.getMessage());
+  }
+
+  @Test
+  void testRefreshTokenResponse_Failure_BlankTokenIsNormalized() {
+    TokenRefreshException exception =
+        assertThrows(TokenRefreshException.class, () -> authService.refreshTokenResponse(" "));
+
+    assertEquals("Invalid or expired token", exception.getMessage());
+    verify(jwtTokenService, never()).extractSessionIdFromToken(anyString());
   }
 
   @Test

--- a/src/test/java/org/jupytereverywhere/service/AuthServiceTest.java
+++ b/src/test/java/org/jupytereverywhere/service/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package org.jupytereverywhere.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -25,9 +26,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class AuthServiceTest {
 
@@ -38,8 +42,8 @@ class AuthServiceTest {
   @InjectMocks private AuthService authService;
 
   @Test
-  void testGenerateInitialTokenResponse_Success() {
-    String expectedToken = "some-jwt-token";
+  void testGenerateInitialTokenResponse_Success(CapturedOutput output) {
+    String expectedToken = "issued-token-sentinel";
     when(jwtTokenService.generateToken(anyString())).thenReturn(expectedToken);
 
     AuthenticationResponse response =
@@ -47,15 +51,16 @@ class AuthServiceTest {
 
     assertNotNull(response);
     assertEquals(expectedToken, response.getToken());
+    assertFalse(output.getAll().contains(expectedToken));
     verify(jwtTokenService).generateToken(anyString());
     verify(tokenStore).storeToken(any(UUID.class), eq(expectedToken));
   }
 
   @Test
-  void testRefreshTokenResponse_Success() {
-    String oldToken = "old-jwt-token";
+  void testRefreshTokenResponse_Success(CapturedOutput output) {
+    String oldToken = "old-token-sentinel";
     UUID sessionId = UUID.randomUUID();
-    String expectedToken = "new-jwt-token";
+    String expectedToken = "new-token-sentinel";
     String notebookId = "notebook-123";
 
     when(jwtTokenService.extractSessionIdFromToken(oldToken)).thenReturn(sessionId);
@@ -69,6 +74,8 @@ class AuthServiceTest {
     assertNotNull(response, "AuthenticationResponse should not be null");
     assertEquals(
         expectedToken, response.getToken(), "The new token should match the expected value");
+    assertFalse(output.getAll().contains(oldToken));
+    assertFalse(output.getAll().contains(expectedToken));
 
     verify(jwtTokenService).extractSessionIdFromToken(oldToken);
     verify(jwtTokenService).extractNotebookIdFromToken(oldToken);
@@ -92,9 +99,9 @@ class AuthServiceTest {
   }
 
   @Test
-  void testGenerateAdminTokenResponse_Success() {
+  void testGenerateAdminTokenResponse_Success(CapturedOutput output) {
     ReflectionTestUtils.setField(authService, "adminSecret", "test-secret");
-    String expectedToken = "admin-jwt-token";
+    String expectedToken = "admin-token-sentinel";
     when(jwtTokenService.generateAdminToken(anyString(), eq("ops-team-1")))
         .thenReturn(expectedToken);
 
@@ -103,6 +110,7 @@ class AuthServiceTest {
 
     assertNotNull(response);
     assertEquals(expectedToken, response.getToken());
+    assertFalse(output.getAll().contains(expectedToken));
     verify(jwtTokenService).generateAdminToken(anyString(), eq("ops-team-1"));
     verify(tokenStore).storeToken(any(UUID.class), eq(expectedToken));
   }

--- a/src/test/java/org/jupytereverywhere/service/JupyterNotebookServiceIntegrationTest.java
+++ b/src/test/java/org/jupytereverywhere/service/JupyterNotebookServiceIntegrationTest.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @TestPropertySource(
     properties = {
       "storage.type=file",
+      "security.jwt.token.secret-key=test-only-jwt-signing-key-32-bytes-minimum",
       "python.interpreter.path=/usr/bin/python3" // Will be mocked in these tests
     })
 class JupyterNotebookServiceIntegrationTest {

--- a/src/test/java/org/jupytereverywhere/service/JwtTokenServiceConfigurationTest.java
+++ b/src/test/java/org/jupytereverywhere/service/JwtTokenServiceConfigurationTest.java
@@ -1,0 +1,70 @@
+package org.jupytereverywhere.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(OutputCaptureExtension.class)
+class JwtTokenServiceConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(AutoConfigurations.of(PropertyPlaceholderAutoConfiguration.class))
+          .withBean(PasswordEncoder.class, BCryptPasswordEncoder::new)
+          .withBean(JwtTokenService.class);
+
+  @Test
+  void missingSigningKeyFailsContextStartup() {
+    contextRunner
+        .withPropertyValues("security.jwt.token.expiration-minutes=60")
+        .run(context -> assertThat(context).hasFailed());
+  }
+
+  @Test
+  void invalidSigningKeyFailsWithoutLoggingItsValue(CapturedOutput output) {
+    String invalidValue = "invalid-value-sentinel";
+
+    contextRunner
+        .withPropertyValues(
+            "security.jwt.token.secret-key=" + invalidValue,
+            "security.jwt.token.expiration-minutes=60")
+        .run(context -> assertThat(context).hasFailed());
+
+    assertFalse(output.getAll().contains(invalidValue));
+  }
+
+  @Test
+  void validSigningConfigurationStartsContext() {
+    contextRunner
+        .withPropertyValues(
+            "security.jwt.token.secret-key=12345678901234567890123456789012",
+            "security.jwt.token.expiration-minutes=60")
+        .run(context -> assertThat(context).hasSingleBean(JwtTokenService.class));
+  }
+
+  @Test
+  void applicationPropertiesHasNoSigningKeyFallback() throws IOException {
+    Properties properties = new Properties();
+    try (InputStream input =
+        getClass().getClassLoader().getResourceAsStream("application.properties")) {
+      assertThat(input).isNotNull();
+      properties.load(input);
+    }
+
+    assertEquals("${JWT_SECRET_KEY}", properties.getProperty("security.jwt.token.secret-key"));
+  }
+}

--- a/src/test/java/org/jupytereverywhere/service/JwtTokenServiceTest.java
+++ b/src/test/java/org/jupytereverywhere/service/JwtTokenServiceTest.java
@@ -127,7 +127,7 @@ class JwtTokenServiceTest {
         Jwts.builder()
             .setClaims(claims)
             .setIssuedAt(new Date(System.currentTimeMillis() - 1000 * 60 * 60))
-            .setExpiration(new Date(System.currentTimeMillis() - 1000 * 30))
+            .setExpiration(new Date(System.currentTimeMillis() - 1000 * 60 * 5))
             .signWith(secretKey, SignatureAlgorithm.HS256)
             .compact();
 
@@ -169,7 +169,7 @@ class JwtTokenServiceTest {
         Jwts.builder()
             .setClaims(claims)
             .setIssuedAt(new Date(System.currentTimeMillis() - 1000 * 60 * 60))
-            .setExpiration(new Date(System.currentTimeMillis() - 1000 * 30))
+            .setExpiration(new Date(System.currentTimeMillis() - 1000 * 60 * 5))
             .signWith(secretKey, SignatureAlgorithm.HS256)
             .compact();
 
@@ -215,7 +215,7 @@ class JwtTokenServiceTest {
         Jwts.builder()
             .setClaims(claims)
             .setIssuedAt(new Date(System.currentTimeMillis() - 1000 * 60 * 60))
-            .setExpiration(new Date(System.currentTimeMillis() - 1000 * 30))
+            .setExpiration(new Date(System.currentTimeMillis() - 1000 * 60 * 5))
             .signWith(secretKey, SignatureAlgorithm.HS256)
             .compact();
 

--- a/src/test/java/org/jupytereverywhere/service/JwtTokenServiceTest.java
+++ b/src/test/java/org/jupytereverywhere/service/JwtTokenServiceTest.java
@@ -16,6 +16,9 @@ import javax.crypto.SecretKey;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -24,6 +27,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
+@ExtendWith(OutputCaptureExtension.class)
 class JwtTokenServiceTest {
 
   private JwtTokenService jwtTokenService;
@@ -98,6 +102,28 @@ class JwtTokenServiceTest {
 
     UUID extractedSessionId = jwtTokenService.extractSessionIdFromToken(expiredToken);
     assertEquals(sessionId, extractedSessionId);
+  }
+
+  @Test
+  void testExpiredTokenDiagnosticsDoNotExposeTokenOrClaims(CapturedOutput output) {
+    String sensitiveClaim = "expired-claim-sentinel";
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("session_id", sessionId.toString());
+    claims.put("notebook_id", sensitiveClaim);
+
+    String expiredToken =
+        Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(new Date(System.currentTimeMillis() - 1000 * 60 * 10))
+            .setExpiration(new Date(System.currentTimeMillis() - 1000 * 60 * 5))
+            .signWith(secretKey, SignatureAlgorithm.HS256)
+            .compact();
+
+    assertEquals(sessionId, jwtTokenService.extractSessionIdFromToken(expiredToken));
+    assertEquals(sensitiveClaim, jwtTokenService.extractNotebookIdFromToken(expiredToken));
+    assertFalse(jwtTokenService.validateToken(expiredToken));
+    assertFalse(output.getAll().contains(expiredToken));
+    assertFalse(output.getAll().contains(sensitiveClaim));
   }
 
   @Test

--- a/src/test/java/org/jupytereverywhere/service/JwtTokenServiceTest.java
+++ b/src/test/java/org/jupytereverywhere/service/JwtTokenServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -34,12 +35,13 @@ class JwtTokenServiceTest {
   private SecretKey secretKey;
   private String validToken;
   private UUID sessionId;
+  private PasswordEncoder passwordEncoder;
 
   @BeforeEach
   void setUp() {
     String secretKeyString = "testSecretKeyForJwtTokenService1234567890";
     secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
-    PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    passwordEncoder = new BCryptPasswordEncoder();
 
     jwtTokenService = new JwtTokenService(secretKeyString, 60, passwordEncoder);
     sessionId = UUID.randomUUID();
@@ -54,6 +56,35 @@ class JwtTokenServiceTest {
             .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60))
             .signWith(secretKey, SignatureAlgorithm.HS256)
             .compact();
+  }
+
+  @Test
+  void testSigningConfigurationRejectsMissingBlankAndShortKeys() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new JwtTokenService(null, 60, passwordEncoder));
+    assertThrows(
+        IllegalArgumentException.class, () -> new JwtTokenService("   ", 60, passwordEncoder));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new JwtTokenService("1234567890123456789012345678901", 60, passwordEncoder));
+  }
+
+  @Test
+  void testSigningConfigurationAcceptsExactly32Bytes() {
+    JwtTokenService service =
+        new JwtTokenService("12345678901234567890123456789012", 60, passwordEncoder);
+    String token = service.generateToken(sessionId.toString());
+    assertTrue(service.validateToken(token));
+  }
+
+  @Test
+  void testSigningConfigurationRejectsNonPositiveExpiration() {
+    String validSecret = "12345678901234567890123456789012";
+    assertThrows(
+        IllegalArgumentException.class, () -> new JwtTokenService(validSecret, 0, passwordEncoder));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new JwtTokenService(validSecret, -1, passwordEncoder));
   }
 
   @Test

--- a/src/test/java/org/jupytereverywhere/utils/HttpHeaderUtilsTest.java
+++ b/src/test/java/org/jupytereverywhere/utils/HttpHeaderUtilsTest.java
@@ -3,6 +3,7 @@ package org.jupytereverywhere.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -174,5 +175,30 @@ class HttpHeaderUtilsTest {
     String headerValue = HttpHeaderUtils.getHeaderValue(request, "X-Test-Header");
 
     assertNull(headerValue, "Header value should be null for an 'unknown' header value");
+  }
+
+  @Test
+  void testGetTokenFromRequest_UsesAuthorizationHeader() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader("Authorization")).thenReturn("Bearer header-token");
+
+    assertEquals("header-token", HttpHeaderUtils.getTokenFromRequest(request));
+  }
+
+  @Test
+  void testGetTokenFromRequest_AcceptsCaseInsensitiveBearerScheme() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader("Authorization")).thenReturn("bEaReR header-token");
+
+    assertEquals("header-token", HttpHeaderUtils.getTokenFromRequest(request));
+  }
+
+  @Test
+  void testGetTokenFromRequest_RejectsQueryParameterToken() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameter("token")).thenReturn("query-token");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> HttpHeaderUtils.getTokenFromRequest(request));
   }
 }

--- a/src/test/java/org/jupytereverywhere/utils/SecretComparisonUtilsTest.java
+++ b/src/test/java/org/jupytereverywhere/utils/SecretComparisonUtilsTest.java
@@ -1,0 +1,21 @@
+package org.jupytereverywhere.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SecretComparisonUtilsTest {
+
+  @Test
+  void constantTimeEqualsAcceptsEqualValues() {
+    assertTrue(SecretComparisonUtils.constantTimeEquals("matching-value", "matching-value"));
+  }
+
+  @Test
+  void constantTimeEqualsRejectsDifferentValuesAndNulls() {
+    assertFalse(SecretComparisonUtils.constantTimeEquals("matching-value", "different-value"));
+    assertFalse(SecretComparisonUtils.constantTimeEquals(null, "matching-value"));
+    assertFalse(SecretComparisonUtils.constantTimeEquals("matching-value", null));
+  }
+}

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
+if [[ -z "${JWT_SECRET_KEY:-}" ]]; then
+  echo "JWT_SECRET_KEY is required; set it to at least 32 UTF-8 bytes before starting." >&2
+  exit 1
+fi
+
 ./gradlew bootRun --no-daemon


### PR DESCRIPTION
- **fix(auth): keep credentials out of diagnostics**
- **fix(auth): fail closed on signing configuration**
- **fix(auth): contain untrusted authentication input**
- **fix(auth): compare shared secrets safely**
- **fix: keep notebook password out of generated toString**
- **test: expire JWTs beyond parser clock skew in expiry tests**
- **chore(release): prepare 0.10.2**
